### PR TITLE
Improve type-related patterns

### DIFF
--- a/doc/pattern-syntax.md
+++ b/doc/pattern-syntax.md
@@ -97,8 +97,15 @@ _ + _
 ```
 
 - Find `instanceof Integer` :
-  - `obj1 instanceof Integer`, `obj2 instanceof Integer`, etc.
+  - `a instanceof Integer`, `b instanceof Integer`, etc.
   
 ```
 _ instanceof Integer
+```
+
+- Find all occurence of `instanceof`
+  - `_ instanceof _`
+
+```
+_ instanceof _
 ```

--- a/grammar/JavaSeeParser.jj
+++ b/grammar/JavaSeeParser.jj
@@ -125,6 +125,18 @@ SPECIAL_TOKEN :
 | <SINGLE_LINE_COMMENT: "//" (~["\n","\r"])*>
 }
 
+/*
+ * PLACEHOLDER
+ */
+TOKEN:
+{
+  <P_INT:          "@int"         >
+| <P_DOUBLE:       "@double"      >
+| <P_BOOLEAN:      "@boolean"     >
+| <P_STRING:       "@String"      >
+
+}
+
 
 /*
  * KEYWORDS
@@ -137,7 +149,6 @@ TOKEN:
 | <K_BYTE:         "byte"         >
 | <K_CASE:         "case"         >
 | <K_CHAR:         "char"         >
-| <K_STRING:       "String"       >
 | <K_CLASS:        "class"        >
 | <K_CONTINUE:     "continue"     >
 | <K_DOUBLE:       "double"       >
@@ -570,8 +581,8 @@ AST.Expression Equal() :{ Token t; AST.Expression a, b; }{
   )* {return a;}
 }
 
-AST.Expression Instanceof(): {Token n, t; AST.Expression a;} {
-  a=Comparative() [ t="instanceof" n=<IDENTIFIER> {a = new AST.InstanceofExpression(p(n), a, c(n));} ] { return a;}
+AST.Expression Instanceof(): {Token n, t; AST.Expression instance; AST.TypeNode type;} {
+  instance=Comparative() [ t="instanceof" type=Type() {instance = new AST.InstanceofExpression(p(t), instance, type);} ] { return instance;}
 }
 
 AST.Expression Comparative() : { Token t; AST.Expression a, b; Token n; }{
@@ -702,6 +713,16 @@ AST.ID Identifier() :{Token t;} {
     t=<IDENTIFIER> {return new AST.ID(p(t), t.image);}
 }
 
+AST.TypeNode Type(): {Token t; AST.TypeNode node;} {
+(
+    t=<K_INT>      {return new AST.PrimitiveTypeNode(p(t), t.image); }
+|   t=<K_DOUBLE>   {return new AST.PrimitiveTypeNode(p(t), t.image); }
+|   t=<K_BOOLEAN>  {return new AST.PrimitiveTypeNode(p(t), t.image); }
+|   t="_"          {return new AST.PlaceholderTypeNode(p(t)); }
+|   t=<IDENTIFIER> {return new AST.ObjectTypeNode(p(t), t.image); }
+)
+}
+
 AST.Expression Wildcard() :{Token t;}{
     t="_"                         {return new AST.Wildcard(p(t));}
 }
@@ -723,12 +744,10 @@ AST.Expression NullPattern() :{Token t;}{
 }
 
 AST.Expression PlaceholderPattern(): {Token t; AST.Expression e;} {
-  t="@" (
-    "int"                    {return new AST.IntWildcard(p(t));}
-  | "double"                 {return new AST.DoubleWildcard(p(t));}
-  | "boolean"                {return new AST.BooleanWildcard(p(t));}
-  | "String"                 {return new AST.StringWildcard(p(t));}
-  )
+    t=<P_INT>                {return new AST.IntWildcard(p(t));}
+  | t=<P_DOUBLE>             {return new AST.DoubleWildcard(p(t));}
+  | t=<P_BOOLEAN>            {return new AST.BooleanWildcard(p(t));}
+  | t=<P_STRING>             {return new AST.StringWildcard(p(t));}
 }
 
 AST.Expression DoublePattern() :{Token t;}{

--- a/src/test/java/com/github/sider/javasee/PatternParserTest.java
+++ b/src/test/java/com/github/sider/javasee/PatternParserTest.java
@@ -337,6 +337,24 @@ public class PatternParserTest {
     }
 
     @Test
+    public void testInstanceof() throws Exception {
+        AST.Expression e;
+        AST.InstanceofExpression et;
+
+        e = parser("_ instanceof String").WholeExpression();
+        assertTrue(e instanceof AST.InstanceofExpression);
+        et = (AST.InstanceofExpression)e;
+        assertTrue(et.target instanceof AST.Wildcard);
+        assertEquals("String", et.type.getName());
+
+        e = parser("_ instanceof _").WholeExpression();
+        assertTrue(e instanceof AST.InstanceofExpression);
+        et = (AST.InstanceofExpression)e;
+        assertTrue(et.target instanceof AST.Wildcard);
+        assertTrue(et.type instanceof AST.PlaceholderTypeNode);
+    }
+
+    @Test
     public void testIntLiteral() throws Exception {
         var e = parser("2").WholeExpression();
         assertTrue(e instanceof AST.IntLiteral);


### PR DESCRIPTION
- placeholder pattern
  - `@int`
  - `@double`
  - `@boolean`
  - `@String`
- instanceof pattern
  - Now `expr instanceof _` is usable
    - matches any type