### PR TITLE
Delete meaningless private modifier

### DIFF
--- a/src/main/java/com/github/sider/javasee/JavaSee.java
+++ b/src/main/java/com/github/sider/javasee/JavaSee.java
@@ -37,7 +37,7 @@ public class JavaSee {
 
         private final int id;
 
-        private ExitStatus(final int id) {
+        ExitStatus(final int id) {
             this.id = id;
         }
 


### PR DESCRIPTION
Note that `private` in enum constructor is redundant