### PR TITLE
Publish docker image on Docker Hub

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+/build
+/.gradle
+/.idea
+/release
+/.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+* [#91](https://github.com/sider/JavaSee/pull/91) Add Docker image
+
 ## 0.1.1 (2019-07-02)
 
 * [#89](https://github.com/sider/JavaSee/pull/89) Fix executable script

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM openjdk:12
+
+RUN mkdir /work /javasee
+
+COPY . /javasee/
+WORKDIR /javasee
+RUN ./gradlew shadowjar && \
+  mv build/libs/JavaSee-all.jar JavaSee-all.jar && \
+  ./gradlew clean && \
+  rm -rf ~/.gradle
+
+WORKDIR /work
+
+ENV JAR_PATH=/javasee/JavaSee-all.jar
+
+ENTRYPOINT ["/javasee/scripts/javasee"]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,20 @@ $ ./gradlew shadowjar
 $ java -jar build/libs/JavaSee-all.jar
 ```
 
+### Docker images
+
+We provide Docker images to help you trying JavaSee without installing Java 11.
+
+- https://hub.docker.com/r/sider/javasee
+
+```
+$ docker pull sider/javasee
+$ docker run -t --rm -v `pwd`:/work sider/javasee
+```
+
+The default `latest` tag points to the latest released version.
+You can pick a tag from version names from [tags list](https://hub.docker.com/r/sider/javasee/tags).
+
 ## Quick start
 
 ```


### PR DESCRIPTION
This allows trying JavaSee without setting up Java 11 environment!

* [x] Add Dockerfile
* [x] Fix Docker Hub configuration
* [x] Update README