### PR TITLE
Output error messages to STDERR instead of STDOUT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+* [#97](https://github.com/sider/JavaSee/pull/97) Output error messages to STDERR instead of STDOUT
+
 ## 0.1.2 (2019-07-04)
 
 * [#91](https://github.com/sider/JavaSee/pull/91) Add Docker image

--- a/src/main/java/com/github/sider/javasee/command/CheckCommand.java
+++ b/src/main/java/com/github/sider/javasee/command/CheckCommand.java
@@ -49,8 +49,8 @@ public class CheckCommand implements CLICommand {
 
         try {
             if(!configPath().isFile()) {
-                out.println("Configuration file " + configPath() + " does not look a file.");
-                out.println("Specify configuration file by -config option");
+                err.println("Configuration file " + configPath() + " does not look a file.");
+                err.println("Specify configuration file by -config option.");
                 return JavaSee.ExitStatus.ERROR;
             }
             var rootPath = Optional.ofNullable(optionRoot).map((root) -> new File(root)).orElse(configPath().getParentFile());


### PR DESCRIPTION
When specifying the `-format json` option as follow, JSON parsing for STDOUT fails.
This change aims to prevent the failure.

```shell
$ java -jar build/libs/JavaSee-all.jar check -format json -config unknown.yml
Configuration file javasee.yml does not look a file.
Specify configuration file by -config option
{
  "issues":[],
  "errors":[]}
```

```shell
$ java -jar build/libs/JavaSee-all.jar check -format json -config unknown.yml 2>/dev/null
{
  "issues":[],
  "errors":[]}
```

```shell
$ java -jar build/libs/JavaSee-all.jar check -format json -config unknown.yml 1>/dev/null
Configuration file unknown.yml does not look a file.
Specify configuration file by -config option
```