### PR TITLE
Fix OutOfMemoryError problem when many .java files are processed

### DIFF
--- a/src/main/java/com/github/sider/javasee/JavaFile.java
+++ b/src/main/java/com/github/sider/javasee/JavaFile.java
@@ -7,6 +7,7 @@ import lombok.ToString;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.function.Supplier;
 
 @ToString
@@ -22,7 +23,7 @@ public class JavaFile {
     public synchronized Node parseFile() {
         var parser = this.parserSupplier.get();
         try {
-            var content = Files.readString(path.toPath());
+            var content = Files.readString(Paths.get(path.toURI()));
             return parser.parse(content).getResult().get();
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/src/main/java/com/github/sider/javasee/JavaFileEnumerator.java
+++ b/src/main/java/com/github/sider/javasee/JavaFileEnumerator.java
@@ -20,7 +20,6 @@ public class JavaFileEnumerator {
     public final Config config;
 
     private void loadScript(File path, BiConsumer<File, JavaFile> block) {
-        JavaParser parser = new JavaParser();
         var script = new JavaFile(path, () -> new JavaParser());
         block.accept(path, script);
     }

--- a/src/main/java/com/github/sider/javasee/JavaFileEnumerator.java
+++ b/src/main/java/com/github/sider/javasee/JavaFileEnumerator.java
@@ -20,14 +20,9 @@ public class JavaFileEnumerator {
     public final Config config;
 
     private void loadScript(File path, BiConsumer<File, JavaFile> block) {
-        try {
-            var content = Files.readString(Paths.get(path.toURI()));
-            JavaParser parser = new JavaParser();
-            var script = new JavaFile(path, parser.parse(content).getResult().get());
-            block.accept(path, script);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        JavaParser parser = new JavaParser();
+        var script = new JavaFile(path, () -> new JavaParser());
+        block.accept(path, script);
     }
 
     private void enumerateFilesInDirectory(File path, Set<File> visit, BiConsumer<File, JavaFile> block) {


### PR DESCRIPTION
- Now JavaSee can GC after processing each .java file
- It may decrease throughput.