### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,21 @@
-FROM openjdk:12
-
-RUN mkdir /work /javasee
+FROM openjdk:14-slim AS builder
 
 COPY . /javasee/
 WORKDIR /javasee
-RUN ./gradlew shadowjar && \
-  mv build/libs/JavaSee-all.jar JavaSee-all.jar && \
-  ./gradlew clean && \
-  rm -rf ~/.gradle
+RUN ./gradlew shadowjar
+
+FROM openjdk:14-slim
+
+COPY --from=builder /javasee/build/libs/JavaSee-all.jar /javasee/JavaSee-all.jar
+COPY --from=builder /javasee/scripts/javasee /javasee/scripts/
+COPY --from=builder /javasee/scripts/javasee.bat /javasee/scripts/
+COPY --from=builder /javasee/CHANGELOG.md /javasee/
+COPY --from=builder /javasee/CREDITS /javasee/
+COPY --from=builder /javasee/LICENSE /javasee/
+COPY --from=builder /javasee/README.md /javasee/
 
 WORKDIR /work
+ENV JAR_PATH /javasee/JavaSee-all.jar
+ENV PATH /javasee/scripts:${PATH}
 
-ENV JAR_PATH=/javasee/JavaSee-all.jar
-
-ENTRYPOINT ["/javasee/scripts/javasee"]
+ENTRYPOINT ["javasee"]


### PR DESCRIPTION
- Bump OpenJDK version in Dockerfile: 12 to 14
  (see also <https://hub.docker.com/_/openjdk/>)
- Use [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/) to reduce the image size.
  (479MB to 420MB)
- Simplify `ENTRYPOINT`.