### PR TITLE
Fix deprecated `set-env` in GitHub Action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
           java-version: ${{ matrix.java }}
       - run: ./gradlew build
       - run: mkdir dist && tar -xvf build/distributions/JavaSee-bin-*.tar -C dist --strip-components 1
-      - run: echo "::set-env name=PATH::${PWD}/dist/bin:${PATH}"
+      - run: echo "${PWD}/dist/bin" >> $GITHUB_PATH
       - run: javasee version
       - run: javasee init
       - run: javasee test

--- a/goodcheck.yml
+++ b/goodcheck.yml
@@ -1,0 +1,9 @@
+import:
+  - https://raw.githubusercontent.com/sider/goodcheck-rules/master/rules/typo.yml
+  - https://raw.githubusercontent.com/sider/goodcheck-rules/master/rules/github.yml
+
+exclude:
+  - .gradle
+  - build
+  - gradle
+  - logo


### PR DESCRIPTION
See also:
- https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
- https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files

Also, this change introduces the useful Goodcheck rules.